### PR TITLE
Removed train_image_size from CoreConfig

### DIFF
--- a/egs/dsb2018/v1/local/train.py
+++ b/egs/dsb2018/v1/local/train.py
@@ -36,6 +36,10 @@ parser.add_argument('--print-freq', '-p', default=10, type=int,
                     help='print frequency (default: 10)')
 parser.add_argument('-b', '--batch-size', default=16, type=int,
                     help='mini-batch size (default: 16)')
+parser.add_argument('--train-image-size', defult=None, type=int,
+                    help='The size of the parts of training images that we train on (in order to' 
+                    ' form a fixed minibatch size). These are derived from the input images'
+                    ' by padding and then random cropping.')
 parser.add_argument('--lr', '--learning-rate', default=0.01, type=float,
                     help='initial learning rate')
 parser.add_argument('--momentum', default=0.9, type=float, help='momentum')
@@ -94,8 +98,8 @@ def main():
     print("offsets are: {}".format(offset_list))
 
     # model configurations from core config
-    image_width = c_config.train_image_size
-    image_height = c_config.train_image_size
+    image_width = args.train_image_size
+    image_height = args.train_image_size
     num_classes = c_config.num_classes
     num_colors = c_config.num_colors
     num_offsets = len(c_config.offsets)

--- a/scripts/waldo/core_config.py
+++ b/scripts/waldo/core_config.py
@@ -47,15 +47,18 @@ class CoreConfig:
         # self.train_image_size).
         self.padding = 10
 
-        # The size of the parts of training images that we train on (in order to
-        # form a fixed minibatch size).  These are derived from the input images
-        # by padding and then random cropping.
-        self.train_image_size = 256
 
-    def validate(self):
+    def validate(self, train_image_size=None):
         """
-        Validate that configuration values are sensible.  Dies on error.
+        Validate that configuration values are sensible.  Dies on error. 
+        Args
+        -----
+        train_image_size: The size of the parts of training images that we train on (in order to
+        form a fixed minibatch size).  These are derived from the input images
+        by padding and then random cropping.
         """
+        self.train_image_size = train_image_size
+
         assert self.num_classes >= 2
         # We can change the assertion that num_colors <= 3 later on if we ever
         # need to operate on images with larger color spaces.
@@ -71,7 +74,8 @@ class CoreConfig:
             assert not (-o[0],-o[1]) in offsets_set
 
         assert self.padding >= 0
-        assert self.train_image_size > 0 and self.train_image_size > 4 * self.padding
+        assert (self.train_image_size is None) 
+            or (self.train_image_size > 0 and self.train_image_size > 4 * self.padding)
 
 
     # write the configuration file to 'filename'
@@ -81,8 +85,7 @@ class CoreConfig:
         except:
             raise Exception("Failed to open file {0} for writing configuration".format(filename))
 
-        for s in [ 'num_classes', 'num_colors',
-                   'padding', 'train_image_size' ]:
+        for s in [ 'num_classes', 'num_colors', 'padding' ]:
             print("{0} {1}".format(s, self.__dict__[s]), file=f)
         print("offsets {}".format('  '.join(['{0} {1}'.format(o[0],o[1]) for o in self.offsets])),
               file=f)
@@ -98,8 +101,7 @@ class CoreConfig:
             a = line.split()
             if len(a) == 0 or a[0][0] == '#':
                 continue
-            if len(a) == 2 and a[0] in [ 'num_classes', 'num_colors',
-                                         'padding', 'train_image_size' ]:
+            if len(a) == 2 and a[0] in [ 'num_classes', 'num_colors', 'padding' ]:
                 # parsing line like: 'num_classes 10'
                 try:
                     self.__dict__[a[0]] = int(a[1])

--- a/scripts/waldo/data_manipulation.py
+++ b/scripts/waldo/data_manipulation.py
@@ -93,7 +93,7 @@ def get_minimum_bounding_box(polygon):
     return points_list
 
 
-def convert_to_combined_image(x, c):
+def convert_to_combined_image(x, c, train_image_size=None):
     """ This function turns an 'image-with-mask' x into a 'combined' image,
     containing both input and supervision information in a single numpy array.
     see 'validate_combined_image' in data_types.py for a description of what
@@ -102,7 +102,7 @@ def convert_to_combined_image(x, c):
     The width of the resulting image will be the same as the image in x:
     this function doesn't do padding, you need to call pad_combined_image.
     """
-    validate_config(c)
+    validate_config(c, train_image_size)
     validate_image_with_mask(x, c)
     im = x['img']
     mask = x['mask']
@@ -110,7 +110,7 @@ def convert_to_combined_image(x, c):
     num_outputs = c.num_classes + len(c.offsets)
     num_all_features = c.num_colors + 2 * num_outputs
     y = np.ndarray(
-        shape=(num_all_features, c.train_image_size, c.train_image_size))
+        shape=(num_all_features, train_image_size, train_image_size))
 
     y[:c.num_colors, :, :] = im
     class_mask = object_class[mask]

--- a/scripts/waldo/data_types.py
+++ b/scripts/waldo/data_types.py
@@ -5,13 +5,13 @@ import numpy as np
 from waldo.core_config import CoreConfig  # import waldo.core_config
 
 
-def validate_config(c):
+def validate_config(c, train_image_size=None):
     """
     This function validates that 'c' is a valid configuration object of
     type CoreConfig.
     """
     assert isinstance(c, CoreConfig)
-    c.validate()
+    c.validate(train_image_size)
 
 
 def validate_image_with_mask(x, c):


### PR DESCRIPTION
Removed train_image_size from CoreConfig and added as argument for functions in data_manipulation and validate() for CoreConfig. Also added it as command line argument in training script for dsb2018 with default value None.

N.B: train_image_size is directly used without a None check in several places. I think we should provide a default value for it other than None otherwise there may be issues down the line. Please provide your thoughts.