### PR TITLE
enable segmentation on test data and generate image masks and submiss…

### DIFF
--- a/egs/dsb2018/v1/local/prepare_data.sh
+++ b/egs/dsb2018/v1/local/prepare_data.sh
@@ -72,6 +72,8 @@ fi
 ### Process data and save it to pytorch path file
 train_prop=0.9
 seed=0
+num_classes=2
+num_colors=3
 . parse_options.sh
 
 mkdir -p data/train
@@ -79,4 +81,10 @@ mkdir -p data/val
 mkdir -p data/stage1_test
 mkdir -p data/stage2_test_final
 
-local/process_data.py --indir $dl_dir --outdir data --train-prop $train_prop --img-channels 3 --seed $seed
+cat <<EOF > data/core.config
+num_classes $num_classes
+num_colors $num_colors
+EOF
+
+local/process_data.py --indir $dl_dir --outdir data \
+		      --train-prop $train_prop --cfg data/core.config --seed $seed

--- a/egs/dsb2018/v1/local/prepare_data.sh
+++ b/egs/dsb2018/v1/local/prepare_data.sh
@@ -9,21 +9,17 @@
 
 dl_dir=data/download
 train_dir=$dl_dir/stage1_train
-train_url=http://s3.amazonaws.com/kaggle-dsb2018/stage1_train.zip
-
 train_label_csv=$dl_dir/stage1_train_labels.csv
-train_label_url=https://s3.amazonaws.com/kaggle-dsb2018/stage1_train_labels.csv.zip
-
-test_dir=$dl_dir/stage1_test
-test_url=https://s3.amazonaws.com/kaggle-dsb2018/stage1_test.zip
+test1_dir=$dl_dir/stage1_test
+test1_solution_csv=$dl_dir/stage1_solution.csv
+test2_dir=$dl_dir/stage2_test_final
 
 mkdir -p $dl_dir
 if [ -d $train_dir ]; then
   echo Not downloading DSB2018 training data as it is already there.
 else
   if [ ! -f $dl_dir/stage1_train.zip ]; then
-    echo Downloading DSB2018 training data...
-    wget -P $dl_dir $train_url || exit 1;
+    kaggle competitions download -c data-science-bowl-2018 -f stage1_train.zip -p $dl_dir
   fi
   unzip -qq $dl_dir/stage1_train.zip -d $train_dir || exit 1;
   echo Done downloading and extracting DSB2018 training data
@@ -34,24 +30,44 @@ if [ -f $train_label_csv ]; then
   echo Not downloading DSB2018 training label csv file as it is already there.
 else
   if [ ! -f $dl_dir/stage1_train_labels.csv.zip ]; then
-    echo Downloading DSB2018 training label csv...
-    wget -P $dl_dir $train_label_url || exit 1;
+    kaggle competitions download -c data-science-bowl-2018 -f stage1_train_labels.csv.zip -p $dl_dir
   fi
   unzip -qq $dl_dir/stage1_train_labels.csv.zip -d $dl_dir || exit 1;
   echo Done downloading and extracting DSB2018 training label csv file
 fi
 
 
-if [ -d $test_dir ]; then
-  echo Not downloading DSB2018 test data as it is already there.
+if [ -d $test1_dir ]; then
+  echo Not downloading DSB2018 stage1_test data as it is already there.
 else
   if [ ! -f $dl_dir/stage1_test.zip ]; then
-    echo Downloading DSB2018 test data...
-    wget -P $dl_dir $test_url || exit 1;
+    kaggle competitions download -c data-science-bowl-2018 -f stage1_test.zip -p $dl_dir
   fi
-  unzip -qq $dl_dir/stage1_test.zip -d $test_dir || exit 1;
-  echo Done downloading and extracting DSB2018 test data
+  unzip -qq $dl_dir/stage1_test.zip -d $test1_dir || exit 1;
+  echo Done downloading and extracting DSB2018 stage1_test data
 fi
+
+if [ -f $test1_solution_csv ]; then
+  echo Not downloading DSB2018 stage1_test solution csv as it is already there.
+else
+  if [ ! -f $dl_dir/stage1_solution.csv.zip ]; then
+    kaggle competitions download -c data-science-bowl-2018 -f stage1_solution.csv.zip -p $dl_dir
+  fi
+  unzip -qq $dl_dir/stage1_solution.csv.zip -d $dl_dir || exit 1;
+  echo Done downloading and extracting DSB2018 stage1_test solution csv file
+fi
+
+
+if [ -d $test2_dir ]; then
+  echo Not downloading DSB2018 stage2_test data as it is already there.
+else
+  if [ ! -f $dl_dir/stage2_test.zip ]; then
+    kaggle competitions download -c data-science-bowl-2018 -f stage2_test_final.zip -p $dl_dir
+  fi
+  unzip -qq $dl_dir/stage2_test_final.zip -d $test2_dir || exit 1;
+  echo Done downloading and extracting DSB2018 stage2_test data
+fi
+
 
 ### Process data and save it to pytorch path file
 train_prop=0.9
@@ -60,6 +76,7 @@ seed=0
 
 mkdir -p data/train
 mkdir -p data/val
-mkdir -p data/test
+mkdir -p data/stage1_test
+mkdir -p data/stage2_test_final
 
-local/process_data.py --train-input $train_dir --test-input $test_dir --outdir data --train-prop $train_prop --img-channels 3 --seed $seed
+local/process_data.py --indir $dl_dir --outdir data --train-prop $train_prop --img-channels 3 --seed $seed

--- a/egs/dsb2018/v1/local/process_data.py
+++ b/egs/dsb2018/v1/local/process_data.py
@@ -10,7 +10,6 @@ import os
 import sys
 import argparse
 import random
-import torch
 import numpy as np
 from PIL import Image
 from waldo.data_io import DataSaver
@@ -28,11 +27,12 @@ parser.add_argument('--seed', default=0, type=int,
 parser.add_argument('--train-prop', default=0.9, type=float,
                     help='Propotion of training data after spliting'
                     'the traing input into training and validation data.')
-parser.add_argument('--img-channels', default=3, type=int,
-                    help='Number of channels for input images')
+parser.add_argument('--cfg', default='data/core.config', type=str,
+                    help='core config file for preparing data')
 
 
-def DataProcess(input_dir, output_dir, split_name, channels, train_prop=0.9):
+def DataProcess(input_dir, output_dir, split_name, cfg, train_prop=0.9):
+    channels = cfg
     split_dir = os.path.join(input_dir, split_name)
     if split_name == 'train':
         # Get train IDs
@@ -45,7 +45,7 @@ def DataProcess(input_dir, output_dir, split_name, channels, train_prop=0.9):
         train_ids = train_all_ids[:num_train]
         val_ids = train_all_ids[num_train:]
 
-        train_saver = DataSaver(os.path.join(output_dir, 'train'))
+        train_saver = DataSaver(os.path.join(output_dir, 'train'), cfg)
 
         print('Getting train images and masks ... ')
         sys.stdout.flush()
@@ -135,6 +135,8 @@ def DataProcess(input_dir, output_dir, split_name, channels, train_prop=0.9):
 if __name__ == '__main__':
     global args
     args = parser.parse_args()
+    cfg = CoreConfig()
+    cfg.read(args.cfg)
 
     split_names = ['train', 'stage1_test', 'stage2_test_final']
     for split in split_names:
@@ -142,6 +144,6 @@ if __name__ == '__main__':
         if not (os.path.exists(ids_file)):
             random.seed(args.seed)
             DataProcess(args.indir, args.outdir, split,
-                        args.img_channels, train_prop=args.train_prop)
+                        cfg, train_prop=args.train_prop)
         else:
             print('Not processing {} data as it is already there.'.format(split))

--- a/egs/dsb2018/v1/local/process_data.py
+++ b/egs/dsb2018/v1/local/process_data.py
@@ -14,13 +14,13 @@ import torch
 import numpy as np
 from PIL import Image
 from waldo.data_io import DataSaver
+from waldo.data_transformation import make_square_image_with_padding
+from waldo.core_config import CoreConfig
 
 parser = argparse.ArgumentParser(
     description='DSB2018 Data Process with Pytorch')
-parser.add_argument('--train-input', default='data/download/stage1_train/', type=str,
-                    help='Path of raw training data')
-parser.add_argument('--test-input', default='data/download/stage1_test/', type=str,
-                    help='Path of raw test data')
+parser.add_argument('--indir', default='data/download', type=str,
+                    help='Path to extracted raw data')
 parser.add_argument('--outdir', default='data', type=str,
                     help='Output directory of processed data')
 parser.add_argument('--seed', default=0, type=int,
@@ -32,10 +32,11 @@ parser.add_argument('--img-channels', default=3, type=int,
                     help='Number of channels for input images')
 
 
-def DataProcess(input_path, output_dir, channels, mode='train', train_prop=0.9):
-    if mode == 'train':
+def DataProcess(input_dir, output_dir, split_name, channels, train_prop=0.9):
+    split_dir = os.path.join(input_dir, split_name)
+    if split_name == 'train':
         # Get train IDs
-        train_all_ids = next(os.walk(input_path))[1]
+        train_all_ids = next(os.walk(split_dir))[1]
         # split the training set into train and validation set
         random.shuffle(train_all_ids)
 
@@ -50,10 +51,11 @@ def DataProcess(input_path, output_dir, channels, mode='train', train_prop=0.9):
         sys.stdout.flush()
         for n, id_ in enumerate(train_ids):
             train_item = {}
-            path = input_path + '/' + id_
+            path = split_dir + '/' + id_
             img = np.array(Image.open(path + '/images/' + id_ +
                                       '.png'))[:, :, :channels]
-
+            # padding if not square
+            img = make_square_image_with_padding(img, channels)
             train_item['img'] = img
             mask = None
             object_id = 1
@@ -65,6 +67,7 @@ def DataProcess(input_path, output_dir, channels, mode='train', train_prop=0.9):
                 else:
                     mask = np.maximum(mask, mask_ * object_id)
                 object_id += 1
+            mask = make_square_image_with_padding(mask, 1)
             train_item['mask'] = mask
             # only object ID 0 belongs to background
             object_class = np.ones(object_id)
@@ -79,10 +82,12 @@ def DataProcess(input_path, output_dir, channels, mode='train', train_prop=0.9):
         sys.stdout.flush()
         for n, id_ in enumerate(val_ids):
             val_item = {}
-            path = input_path + '/' + id_
+            path = split_dir + '/' + id_
             img = np.array(Image.open(path + '/images/' +
                                       id_ + '.png'))[:, :, :channels]
 
+            # padding if not square
+            img = make_square_image_with_padding(img, channels)
             val_item['img'] = img
             mask = None
             object_id = 1
@@ -94,6 +99,7 @@ def DataProcess(input_path, output_dir, channels, mode='train', train_prop=0.9):
                 else:
                     mask = np.maximum(mask, mask_ * object_id)
                 object_id += 1
+            mask = make_square_image_with_padding(mask, 1)
             val_item['mask'] = mask
             object_class = np.ones(object_id)
             object_class[0] = 0
@@ -105,42 +111,37 @@ def DataProcess(input_path, output_dir, channels, mode='train', train_prop=0.9):
 
     else:
         # Get test images
-        print('Getting test images ... ')
-        test_ids = next(os.walk(input_path))[1]
-        test = []
+        test_saver = DataSaver(os.path.join(
+            output_dir, split_name), train=False)
+        print('Getting {} images ... '.format(split_name))
+        test_ids = next(os.walk(split_dir))[1]
         sys.stdout.flush()
         for n, id_ in enumerate(test_ids):
             test_item = {}
-            test_item['name'] = id_
-            path = input_path + '/' + id_
+            path = split_dir + '/' + id_
             img = np.array(Image.open(path + '/images/' +
-                                      id_ + '.png'))[:, :, :channels]
+                                      id_ + '.png'))
+            if len(img.shape) == 2 and channels == 3:
+                # expand and reshape it to size:(height, width, channels)
+                img = np.moveaxis(np.array([img, img, img]), 0, -1)
+            else:
+                img = img[:, :, :channels]
             test_item['img'] = img
-            test.append(test_item)
-
-        print('Done with test set!')
+            test_saver.write_image(id_, test_item)
+        test_saver.write_index()
+        print('Done with {} set!'.format(split_name))
 
 
 if __name__ == '__main__':
     global args
     args = parser.parse_args()
 
-    train_ids_file = "{0}/train/image_ids.txt".format(args.outdir)
-    val_ids_file = "{0}/val/image_ids.txt".format(args.outdir)
-    if not (os.path.exists(train_ids_file) and
-            os.path.exists(val_ids_file)):
-        random.seed(args.seed)
-        DataProcess(args.train_input,
-                    args.outdir,
-                    args.img_channels, mode='train',
-                    train_prop=args.train_prop)
-
-    else:
-        print('Not processing training and validation data as it is already there.')
-
-    # test_output = "{0}/test/test.pth.tar".format(args.outdir)
-    # if not (os.path.exists(test_output)):
-    #     test = DataProcess(args.test_input, args.img_channels, mode='test')
-    #     torch.save(test, test_output)
-    # else:
-    #     print('Not processing test data as it is already there.')
+    split_names = ['train', 'stage1_test', 'stage2_test_final']
+    for split in split_names:
+        ids_file = "{0}/{1}/image_ids.txt".format(args.outdir, split)
+        if not (os.path.exists(ids_file)):
+            random.seed(args.seed)
+            DataProcess(args.indir, args.outdir, split,
+                        args.img_channels, train_prop=args.train_prop)
+        else:
+            print('Not processing {} data as it is already there.'.format(split))

--- a/egs/dsb2018/v1/local/segment.py
+++ b/egs/dsb2018/v1/local/segment.py
@@ -18,9 +18,9 @@ from unet_config import UnetConfig
 
 
 parser = argparse.ArgumentParser(description='Pytorch DSB2018 setup')
-parser.add_argument('--test-data', default='data/stage1_test', type=str,
+parser.add_argument('--test-data', type=str, required=True,
                     help='Path to test images to be segmented')
-parser.add_argument('--dir', type=str,
+parser.add_argument('--dir', type=str, required=True,
                     help='Directory to store segmentation results. '
                     'It is assumed that <dir> is a sub-directory of '
                     'the model directory.')

--- a/egs/dsb2018/v1/local/train.py
+++ b/egs/dsb2018/v1/local/train.py
@@ -50,8 +50,6 @@ parser.add_argument('--weight-decay', '--wd', default=5e-4, type=float,
                     help='weight decay (default: 5e-4)')
 parser.add_argument('--train-dir', default='data', type=str,
                     help='Directory of processed training and validation data')
-parser.add_argument('--test-dir', default='data/test', type=str,
-                    help='Directory of processed test data')
 parser.add_argument('--tensorboard',
                     help='Log progress to TensorBoard', action='store_false')
 parser.add_argument('--core-config', default='', type=str,
@@ -295,7 +293,7 @@ def soft_dice_loss(inputs, targets):
 
 
 def adjust_learning_rate(optimizer, epoch):
-    """Sets the learning rate to the initial LR divided by 5 at 60th, 120th and 160th epochs"""
+    """Sets the learning rate to the initial LR divided by 5 at 60th and 100th epochs"""
     lr = args.lr * ((0.2 ** int(epoch >= 60)) *
                     (0.2 ** int(epoch >= 100)))
     # log to TensorBoard

--- a/egs/dsb2018/v1/local/tuning/run_unet_1a.sh
+++ b/egs/dsb2018/v1/local/tuning/run_unet_1a.sh
@@ -11,7 +11,7 @@ epochs=10
 start_filters=64
 batch_size=16
 lr=0.01
-dir=
+dir=exp/unet_1a
 
 . ./cmd.sh
 . ./path.sh

--- a/egs/dsb2018/v1/local/tuning/run_unet_1a.sh
+++ b/egs/dsb2018/v1/local/tuning/run_unet_1a.sh
@@ -11,13 +11,13 @@ epochs=10
 start_filters=64
 batch_size=16
 lr=0.01
+dir=
 
 . ./cmd.sh
 . ./path.sh
 . ./scripts/parse_options.sh
 
 
-dir=exp/unet_1a
 
 
 if [ $stage -le 1 ]; then
@@ -28,7 +28,7 @@ if [ $stage -le 1 ]; then
   num_classes $num_classes
   num_colors $num_colors
   padding $padding
-  offsets 1 0  0 1  -2 -1  1 -2
+  offsets 1 0  0 1  -2 -1  1 -2 
 EOF
 
   cat <<EOF > $dir/configs/unet.config

--- a/egs/dsb2018/v1/requirements.txt
+++ b/egs/dsb2018/v1/requirements.txt
@@ -1,2 +1,4 @@
 # This file contains dependencies for this individual experiment.
 # For common dependencies shared by all experiments, please refer to: ./scripts/dependencies/requirement.txt 
+
+kaggle

--- a/egs/dsb2018/v1/run.sh
+++ b/egs/dsb2018/v1/run.sh
@@ -37,7 +37,7 @@ if [ $stage -le 2 ]; then
     --train-image-size 128 \
     --model model_best.pth.tar \
     --test-data data/stage1_test \
-    --dir $dir/segment
-    --csv 'sub-dsbowl2018.csv'
+    --dir $dir/segment \
+    --csv sub-dsbowl2018.csv
 
 fi

--- a/egs/dsb2018/v1/run.sh
+++ b/egs/dsb2018/v1/run.sh
@@ -23,12 +23,12 @@ if [ $stage -le 0 ]; then
 fi
 
 
-epochs=10
+epochs=120
 depth=5
 dir=exp/unet_${depth}_${epochs}_sgd
 if [ $stage -le 1 ]; then
   # training
-  local/run_unet.sh --epochs $epochs --depth $depth
+  local/run_unet.sh --dir $dir --epochs $epochs --depth $depth
 fi
 
 if [ $stage -le 2 ]; then
@@ -36,7 +36,8 @@ if [ $stage -le 2 ]; then
   local/segment.py \
     --train-image-size 128 \
     --model model_best.pth.tar \
-    data/val \
-    $dir/segment_val
+    --test-data data/stage1_test \
+    --dir $dir/segment
+    --csv 'sub-dsbowl2018.csv'
 
 fi

--- a/scripts/waldo/data_io.py
+++ b/scripts/waldo/data_io.py
@@ -7,13 +7,14 @@ import torch
 import numpy as np
 from skimage.transform import resize
 from torch.utils.data import Dataset
-from waldo.data_manipulation import convert_to_combined_image
+from waldo.data_manipulation import convert_to_combined_image, compress_image_with_mask
 from waldo.data_transformation import randomly_crop_combined_image
 
 
 class DataSaver:
-    def __init__(self, dir, train=True):
+    def __init__(self, dir, cfg, train=True):
         self.dir = dir
+        self.cfg = cfg
         if train:
             self.suffixes = ['img', 'mask', 'object_class']
         else:
@@ -28,10 +29,13 @@ class DataSaver:
 
     def write_image(self, name, image_with_mask):
         """ This function accepts a image_with_mask object and its name, and saves
-            its img, mask and object_class as a numpy array under the given directory (
-            i.e. dir/numpy_arrays/name.suffix.npy)
+            its img, mask and object_class as a numpy array under the given directory
+            (i.e. dir/numpy_arrays/name.suffix.npy)
         """
         self.__validate_name(name)
+        if self.train:
+            image_with_mask = compress_image_with_mask(
+                image_with_mask, self.cfg)
 
         for suffix in self.suffixes:
             path = os.path.join(self.dir, suffix)
@@ -63,12 +67,14 @@ class DataSaver:
 
 
 class WaldoDataset(Dataset):
-    def __init__(self, dir, c_cfg, size, cache=True):
+    def __init__(self, dir, c_cfg, size, cache=True, mask=False, crop=True):
         self.c_cfg = c_cfg
         self.size = size
         self.dir = dir
         self.cache = cache
         self.data = []
+        self.mask = mask
+        self.crop = crop
         with open(self.dir + '/' + 'image_ids.txt', 'r') as ids_file:
             self.ids = ids_file.readlines()
         self.ids = [id.strip() for id in self.ids]
@@ -91,6 +97,14 @@ class WaldoDataset(Dataset):
         return image_with_mask
 
     def __getitem__(self, index):
+        """ This function is called when we use iter (e.g. dataloader) to load data from
+            the dataset.
+            It returns:
+                img: image
+                class_label: feature maps regarding classification
+                bound: feature maps regarding sameness
+                image_with_mask['mask'] (with mask=True): ground truth of segmentation on image 
+        """
         if self.cache:
             image_with_mask = self.data[index]
         else:
@@ -100,18 +114,22 @@ class WaldoDataset(Dataset):
         n_classes = self.c_cfg.num_classes
         n_offsets = len(self.c_cfg.offsets)
         n_colors = self.c_cfg.num_colors
-        cropped_img = randomly_crop_combined_image(
-            combined_img, self.c_cfg, self.size, self.size)
+        if self.crop:
+            combined_img = randomly_crop_combined_image(
+                combined_img, self.c_cfg, self.size, self.size)
 
         img = torch.from_numpy(
-            cropped_img[:n_colors, :, :])
+            combined_img[:n_colors, :, :])
         class_label = torch.from_numpy(
-            cropped_img[n_colors:n_colors + n_classes, :, :])
+            combined_img[n_colors:n_colors + n_classes, :, :])
         bound = torch.from_numpy(
-            cropped_img[n_colors + n_classes:n_colors +
-                        n_classes + n_offsets, :, :])
+            combined_img[n_colors + n_classes:n_colors +
+                         n_classes + n_offsets, :, :])
 
-        return img, class_label, bound
+        if self.mask:
+            return img, class_label, bound, image_with_mask['mask']
+        else:
+            return img, class_label, bound
 
     def __len__(self):
         return len(self.ids)
@@ -144,6 +162,13 @@ class WaldoTestset(Dataset):
         return np.load(filename)
 
     def __getitem__(self, index):
+        """ This function is called when we use iter (e.g. dataloader) to load data from
+            the dataset. 
+            It returns:
+               img_tensor: resized image
+               size: image original size for future recovering reason
+               id: image ID
+        """
         id = self.ids[index]
         if self.cache:
             img = self.data[index]

--- a/scripts/waldo/data_transformation.py
+++ b/scripts/waldo/data_transformation.py
@@ -21,9 +21,10 @@ def randomly_crop_combined_image(combined_image, config,
 
     n_channels, height, width = combined_image.shape
 
-    if height < image_height or width < image_width:
-        cropped_image = np.zeros((n_channels, image_height, image_width))
-        cropped_image[:, :height, :width] = combined_image
+    # it has been made a square image and we only consider one side
+    if height <= image_height:
+        cropped_image = np.pad(
+            combined_image, ((0, 0), (0, image_height - height), (0, image_width - width)), 'constant')
     else:
         top = np.random.randint(0, height - image_height)
         left = np.random.randint(0, width - image_width)
@@ -90,7 +91,7 @@ def scale_down_image_with_objects(image_with_objects, config, max_size):
     return resized_image_with_objects
 
 
-def make_square_image_with_padding(im_arr, config):
+def make_square_image_with_padding(im_arr, num_colors):
     """
     This function pads an image to make it squre, if both height and width are
     different, (Otherwise it leaves it the same size).
@@ -99,6 +100,7 @@ def make_square_image_with_padding(im_arr, config):
     'image', it does not make a deep copy.
     """
 
+    assert num_colors == 1 or num_colors == 3
     height = int(im_arr.shape[0])
     width = int(im_arr.shape[1])
 
@@ -106,17 +108,20 @@ def make_square_image_with_padding(im_arr, config):
         return im_arr
 
     if width > height:
-        diff = width-height
-        if config.num_colors == 1:
-            im_arr_pad  = np.pad(im_arr, [(0, diff), (0, 0)], mode='constant', constant_values=255)
+        diff = width - height
+        if num_colors == 1:
+            im_arr_pad = np.pad(
+                im_arr, [(0, diff), (0, 0)], mode='constant')
         else:
-            im_arr_pad = np.pad(im_arr, [(0, diff), (0, 0), (0,0)], mode='constant', constant_values=255)
+            im_arr_pad = np.pad(
+                im_arr, [(0, diff), (0, 0), (0, 0)], mode='constant')
     else:
         diff = height - width
-        if config.num_colors == 1:
-            im_arr_pad = np.pad(im_arr, [(0, 0), (0, diff)], mode='constant', constant_values=255)
+        if num_colors == 1:
+            im_arr_pad = np.pad(
+                im_arr, [(0, 0), (0, diff)], mode='constant')
         else:
-            im_arr_pad = np.pad(im_arr, [(0, 0), (0, diff), (0, 0)], mode='constant', constant_values=255)
+            im_arr_pad = np.pad(
+                im_arr, [(0, 0), (0, diff), (0, 0)], mode='constant')
 
     return im_arr_pad
-

--- a/scripts/waldo/data_transformation.py
+++ b/scripts/waldo/data_transformation.py
@@ -97,7 +97,7 @@ def make_square_image_with_padding(im_arr, num_colors):
     different, (Otherwise it leaves it the same size).
     It returns the padded image; but note, if it does not have
     to pad the image, it just returns the input variable
-    'image', it does not make a deep copy.
+    'image', it does not make a deep copy. Note: it only pads on the right or bottom side.
     """
 
     assert num_colors == 1 or num_colors == 3

--- a/scripts/waldo/segmenter.py
+++ b/scripts/waldo/segmenter.py
@@ -19,9 +19,12 @@ import resource
 import scipy.misc
 from collections import namedtuple
 
+
 SegmenterOptions = namedtuple('SegmenterOptions',
                               ['same_different_bias',
                                'object_merge_factor'])
+
+
 class ObjPair:
     """
     This class is used to make an unordered pair from 2 Objects.
@@ -149,7 +152,6 @@ class AdjacencyRecord:
               out class_delta_log_prob.
     """
 
-
     def __init__(self, obj1, obj2, segmenter):
         self.obj1 = obj1
         self.obj2 = obj2
@@ -161,7 +163,6 @@ class AdjacencyRecord:
         self.merged_class = None
         self.merge_priority = None
         self.update_merge_priority(segmenter)
-
 
     def compute_obj_merge_logprob(self, segmenter):
         logprob = 0
@@ -192,7 +193,6 @@ class AdjacencyRecord:
                     logprob += log_same_prob - log_different_prob
         self.obj_merge_logprob = logprob if adjacent else None
 
-
     def compute_class_delta_logprob(self):
         if self.obj1.object_class == self.obj2.object_class:
             self.class_delta_logprob, self.merged_class = 0.0, self.obj1.object_class
@@ -201,7 +201,7 @@ class AdjacencyRecord:
             self.merged_class = np.argmax(joint_class_logprobs)
             merged_class_joint_logprob = joint_class_logprobs[self.merged_class]
             self.class_delta_logprob = merged_class_joint_logprob - \
-                            self.obj1.class_logprob() - self.obj2.class_logprob()
+                self.obj1.class_logprob() - self.obj2.class_logprob()
 
     def update_merge_priority(self, segmenter):
         self.compute_class_delta_logprob()
@@ -211,7 +211,6 @@ class AdjacencyRecord:
 
     def obj_pair(self):
         return ObjPair(self.obj1, self.obj2)
-
 
     def print(self):
         print("Objects in arec {}:".format(self))
@@ -231,19 +230,20 @@ class AdjacencyRecord:
 
 class ObjectSegmenter:
     def __init__(self, nnet_class_probs, nnet_sameness_probs, num_classes,
-                 offsets, opts = None):
+                 offsets, opts=None):
         self.opts = opts
         if self.opts is None:
             self.opts = self.default_options()
         print(self.opts)
-        epsilon = sys.float_info.epsilon
+        epsilon = np.finfo(np.float32).eps
         self.class_probs = nnet_class_probs.clip(epsilon, 1.0 - epsilon)
         self.sameness_probs = nnet_sameness_probs.clip(epsilon, 1.0 - epsilon)
         if self.opts.same_different_bias != 0.0:
             sameness_probs_biased_logit = (np.log(self.sameness_probs) -
                                            np.log(1.0 - self.sameness_probs) +
                                            self.opts.same_different_bias)
-            self.sameness_probs = 1.0 / (1.0 + np.exp(-sameness_probs_biased_logit))
+            self.sameness_probs = 1.0 / \
+                (1.0 + np.exp(-sameness_probs_biased_logit))
         self.num_classes = num_classes
         self.offsets = offsets  # should be a list of tuples
         # the pixels here are python tuples (x,y) not numpy arrays
@@ -262,8 +262,8 @@ class ObjectSegmenter:
         self.show_stats()
 
     def default_options(self):
-        return SegmenterOptions(same_different_bias = 0.0,
-                                object_merge_factor = 1.0)
+        return SegmenterOptions(same_different_bias=0.0,
+                                object_merge_factor=1.0)
 
     def init_objects_and_adjacency_records(self):
         print("Initializing the segmenter...")
@@ -312,7 +312,8 @@ class ObjectSegmenter:
         print("Top 10 biggest objs (#pixels): {}".format(pixperobj[:10]))
         adjlistsize = sorted([len(obj.adjacency_list)
                               for obj in self.objects.values()], reverse=True)
-        print("Top 10 biggest objs (adj_list size): {}".format(adjlistsize[:10]))
+        print("Top 10 biggest objs (adj_list size): {}".format(
+            adjlistsize[:10]))
 
     def compute_total_logprob(self):
         tot_class_logprob = 0
@@ -326,7 +327,6 @@ class ObjectSegmenter:
         return tot_class_logprob + (tot_differentness_logprob +
                                     tot_sameness_logprob) * self.opts.object_merge_factor
 
-
     def visualize(self, iter):
         img = np.zeros((self.img_height, self.img_width))
         k = 1
@@ -339,7 +339,7 @@ class ObjectSegmenter:
         scipy.misc.imsave('{}.png'.format(iter), img)
 
     def output_mask(self):
-        mask = np.zeros((self.img_height, self.img_width))
+        mask = np.zeros((self.img_height, self.img_width), dtype=int)
         k = 1
         object_class = []
         for obj in self.objects.values():
@@ -391,7 +391,6 @@ class ObjectSegmenter:
                         sys.exit(1)
 
         assert tot_obj_adj_records == 2 * len(self.adjacency_records)
-
 
     def run_segmentation(self):
         """ This is the top-level function that performs the optimization.
@@ -451,7 +450,8 @@ class ObjectSegmenter:
                     print("Merging...{:0.2f} >= {:0.2f}\n".format(
                         arec.merge_priority, merge_priority), file=sys.stderr)
                 self.merge(arec)
-                if self.do_debugging and np.random.random() > 0.999: self.debug()
+                if self.do_debugging and np.random.random() > 0.999:
+                    self.debug()
             elif arec.merge_priority >= 0.0:
                 if self.verbose >= 1:
                     print("Pushing with new mp: {:0.2f}\n".format(
@@ -467,7 +467,6 @@ class ObjectSegmenter:
         self.show_stats()
         self.visualize('final')
         return self.output_mask()
-
 
     def merge(self, arec):
         """ This is the most nontrivial aspect of the algorithm: how to merge objects.
@@ -504,7 +503,8 @@ class ObjectSegmenter:
         if len(obj2.pixels) > len(obj1.pixels):
             obj1, obj2 = obj2, obj1
 
-        assert np.abs(arec.obj_merge_logprob - (arec.sameness_logprob - arec.differentness_logprob)) < 0.001
+        assert np.abs(arec.obj_merge_logprob -
+                      (arec.sameness_logprob - arec.differentness_logprob)) < 0.001
 
         if self.do_debugging:
             old_logprob = arec.obj_merge_logprob
@@ -545,7 +545,8 @@ class ObjectSegmenter:
                 that_arec.obj_merge_logprob += this_arec.obj_merge_logprob
                 that_arec.differentness_logprob += this_arec.differentness_logprob
                 that_arec.sameness_logprob += this_arec.sameness_logprob
-                this_arec.merge_priority = -1.0  # make sure it is practically deleted from the queue
+                # make sure it is practically deleted from the queue
+                this_arec.merge_priority = -1.0
                 self.adjacency_records[that_arec.obj_pair()] = that_arec
                 obj3.adjacency_list[that_arec.obj_pair()] = that_arec
                 that_arec.update_merge_priority(self)


### PR DESCRIPTION
changes including:
(1) use kaggle instead of wget to download data. Previously I downloaded the data and uploaded it to amazon s3 for wget downloading. But it seems not obey the license since only kaggle users can download this data. In addition, we will need "kaggle" api for submitting results. So I changed it to kaggle here.
kaggle can be easily installed by pip install kaggle. But we need to put our account info in ~/.kaggle as [https://github.com/Kaggle/kaggle-api](url) instructs. I haven't updated dependency-related stuff. I think we can finish it later.
(2) now we can run segmentation on all test data (stage1_test) and get a run-length encoding file as the result. The segmentation results for each image is also stored on the disk thus we can better get an intuition on the quality of the segmentation.

TODO:
There are actually three data splits in total for this competition: train, stage1_test, stage2_test. Previously we only download train (further split into train and val) and stage1_test. Both of these two parts are provided with a ground truth in a csv file format (same way as I store). Stage2_test is the final test data without ground truth accessible yet. We need to write our segmentation result in csv file format and submit it to their official competition website [https://www.kaggle.com/c/data-science-bowl-2018/data](url) or via `kaggle competitions submit -c data-science-bowl-2018 -f submission.csv -m "Message"`. Stage2_test (3019) is also much larger compared to stage1_test (65).  So for now I think we'd better use stage1_test to tune the segmenter or network stuff. 
In conclusion, if you want to see our final results and compare it with other submission on leadboard,  just change `--test-data data/stage1_test` to `--test-data data/stage2_test_final` in run.sh, but it will take a quite long time (haven't done parallelization yet). Otherwise, if you want to tune the setup and do a quick test, you can use the default stage1_test. But for now, the scoring code is not finished yet, you can only see the encoded results and the visualized masks. 