### PR TITLE
Add various improvements to segmenter and visualization

### DIFF
--- a/egs/madcat_arabic/v1/local/segment.py
+++ b/egs/madcat_arabic/v1/local/segment.py
@@ -32,12 +32,18 @@ parser.add_argument('--train-image-size', default=128, type=int,
                     'These are derived from the input images'
                     ' by padding and then random cropping.')
 parser.add_argument('--object-merge-factor', type=float, default=None,
-                    help='Scale for object merge scores in the segmentaion '
+                    help='Scale for object merge scores in the segmentation '
                     'algorithm. If not set, it will be set to '
                     '1.0 / num_offsets by default.')
 parser.add_argument('--same-different-bias', type=float, default=0.0,
                     help='Bias for same/different probs in the segmentation '
                     'algorithm.')
+parser.add_argument('--merge-logprob-bias', type=float, default=0.0,
+                    help='A bias that is added to merge logprobs in the '
+                    'segmentation algorithm.')
+parser.add_argument('--prune-threshold', type=float, default=0.0,
+                    help='Threshold used in the pruning step of the '
+                    'segmentation algorithm. Higher values --> more pruning.')
 parser.add_argument('--csv', type=str, default='sub-dsbowl2018.csv',
                     help='Csv filename as the final submission file')
 parser.add_argument('--job', type=int, default=0, help='job id')
@@ -123,42 +129,45 @@ def segment(dataloader, segment_dir, model, core_config):
 
     num_classes = core_config.num_classes
     offset_list = core_config.offsets
+    if args.object_merge_factor is None:
+        args.object_merge_factor = 1.0 / len(offset_list)
+    segmenter_opts = SegmenterOptions(same_different_bias=args.same_different_bias,
+                                      object_merge_factor=args.object_merge_factor,
+                                      merge_logprob_bias=args.merge_logprob_bias)
 
     for i, (img, size, id) in enumerate(dataloader):
         id = id[0]  # tuple to str
         if id + '.png' in exist_ids:
             continue
         original_height, original_width = size[0].item(), size[1].item()
+        print("Processing image '{}'...".format(id))
         with torch.no_grad():
             output = model(img)
-            # class_pred = (output[:, :num_classes, :, :] + 0.001) * 0.999
-            # adj_pred = (output[:, num_classes:, :, :] + 0.001) * 0.999
             class_pred = output[:, :num_classes, :, :]
             adj_pred = output[:, num_classes:, :, :]
 
-        if args.object_merge_factor is None:
-            args.object_merge_factor = 1.0 / len(offset_list)
-            segmenter_opts = SegmenterOptions(same_different_bias=args.same_different_bias,
-                                              object_merge_factor=args.object_merge_factor)
         seg = ObjectSegmenter(class_pred[0].detach().numpy(),
                               adj_pred[0].detach().numpy(),
                               num_classes, offset_list,
                               segmenter_opts)
-        mask_pred, object_class = seg.run_segmentation()
+        seg.run_segmentation()
+        seg.prune(args.prune_threshold)
+        mask_pred, object_class = seg.output_mask()
         #mask_pred = resize(mask_pred, (original_height, original_width),
         #                   order=0, preserve_range=True).astype(int)
 
-        image_with_mask = {}
+
         img = np.moveaxis(img[0].detach().numpy(), 0, -1)
         #img = resize(img, (original_height, original_width),
         #             preserve_range=True)
-        image_with_mask['img'] = img
-        image_with_mask['mask'] = mask_pred
-        image_with_mask['object_class'] = object_class
-        visual_mask = visualize_mask(image_with_mask, core_config)[
-            'img_with_mask']
-        scipy.misc.imsave('{}/{}.png'.format(img_dir, id), visual_mask)
-        #scipy.misc.imsave('{}/{}.png'.format(mask_dir, id), mask_pred)
+        segmented_img = {}
+        segmented_img['img'] = img
+        segmented_img['mask'] = mask_pred
+        segmented_img['object_class'] = object_class
+        visualize_mask(segmented_img, core_config)
+        scipy.misc.imsave('{}/{}.png'.format(img_dir, id),
+                          segmented_img['img_with_mask'])
+
         filename = mask_dir + '/' + id + '.' + 'mask' + '.npy'
         np.save(filename, mask_pred)
         rles = list(mask_to_rles(mask_pred))
@@ -168,6 +177,7 @@ def segment(dataloader, segment_dir, model, core_config):
                 obj_str = ' '.join(str(n) for n in obj)
                 fh.write(obj_str)
                 fh.write('\n')
+        print("\n\n")
 
 
 def rle_encoding(x):
@@ -215,4 +225,3 @@ def make_submission(segment_dir, csvname):
 
 if __name__ == '__main__':
     main()
-

--- a/egs/madcat_arabic/v1/run.sh
+++ b/egs/madcat_arabic/v1/run.sh
@@ -46,6 +46,8 @@ if [ $stage -le 2 ]; then
   $cmd JOB=1:$nj $logdir/segment.JOB.log local/segment.py \
        --train-image-size 256 \
        --model model_best.pth.tar \
+       --object-merge-factor 1.0 \
+       --prune-threshold 500.0 \
        --test-data data/test \
        --dir $dir/segment \
        --job JOB --num-jobs $nj

--- a/scripts/waldo/data_visualization.py
+++ b/scripts/waldo/data_visualization.py
@@ -1,4 +1,5 @@
 # Copyright      2018  Johns Hopkins University (author: Daniel Povey, Desh Raj, Adel Rahimi)
+#                      Hossein Hadian
 
 # Apache 2.0
 import matplotlib
@@ -8,46 +9,55 @@ import matplotlib.pyplot as plt
 import numpy as np
 from PIL import Image
 from io import BytesIO
+import operator
 
 from waldo.data_types import *
 
 
-def visualize_mask(x, c, transparency=0.3):
+def visualize_mask(x, c, transparency=0.7, show_labels=True):
     """
     This function accepts an object x that should represent an image with a
-    mask, a config class c, and a float 0 < transparency < 1.  
-    It changes the image in-place by overlaying the mask with transparency 
+    mask, a config class c, and a float 0 < transparency < 1.
+    It changes the image in-place by overlaying the mask with transparency
     described by the parameter.
     x['img_with_mask'] = image with transparent mask overlay
     """
 
-    def get_cmap(n, name='hsv'):
-        '''Returns a function that maps each index in 0, 1, ..., n-1 to a distinct 
-        RGB color; the keyword argument name must be a standard mpl colormap name.
-        '''
-        return plt.cm.get_cmap(name, n)
-
-
-    def get_colored_mask(mask, n, cmap):
-        """Given a BW mask, number of objects, and a LinearSegmentedColormap object, 
-        returns a RGB mask.
-        """
-        shuffled_n = np.random.permutation(np.array([i for i in range(n)]))
-        color_mask = np.array([cmap(shuffled_n[i]) for i in mask])
-        return color_mask
-
-
-
     validate_image_with_mask(x, c)
     im = x['img']
     mask = x['mask']
-    
-    num_objects = np.unique(mask).shape[0]
-    cmap = get_cmap(num_objects)
-    mask_rgb = get_colored_mask(mask,num_objects,cmap)
 
+    num_objects = np.unique(mask).shape[0]
+    colormap = plt.cm.get_cmap('hsv', num_objects)
+
+    shuffled_object_ids = np.random.permutation(np.array(list(range(num_objects))))
+    color_mask = np.array([colormap(shuffled_object_ids[i]) for i in mask])
+    obj2center = {}
+    obj2size = {}
+    for row in range(len(mask)):
+        for col in range(len(mask[row])):
+            objid = mask[row, col]
+            obj2center[objid] = (obj2center[objid] + (row, col) if objid in
+                                 obj2center else np.array((row, col)))
+            obj2size[objid] = (obj2size[objid] + 1 if objid in obj2size
+                               else 1)
+            objclass = x['object_class'][objid]
+            # set any background to white:
+            if objclass == 0: color_mask[row, col] = [1, 1, 1, 1]
+    for objid in obj2center:
+        obj2center[objid] = tuple(np.round(obj2center[objid] /
+                                           obj2size[objid]).astype(int))
+    plt.clf()
     plt.imshow(im)
-    plt.imshow(mask_rgb, alpha=transparency)
+    plt.imshow(color_mask, alpha=transparency)
+    if show_labels:
+        for objid in obj2center:
+            center = obj2center[objid]
+            color = colormap(shuffled_object_ids[objid])
+            plt.text(center[1] - 2, center[0] + 2, '{}'.format(objid), fontsize=7,
+                     color=color, bbox=dict(facecolor='white',
+                                            edgecolor='none', pad=0))
+
     plt.subplots_adjust(0,0,1,1)
     buffer_ = BytesIO()
     plt.savefig(buffer_, format = "png")


### PR DESCRIPTION
Main things in this PR:
- Improve visualization by showing labels for objects. It was a bit hard to improve the segmenter code w/o seeing everything in the image.
- Add pruning to the segmenter code based on background logprob difference with class logprob. This basically solved the tiny-objects issue completely. A few segmented test images with pruning (note the background label is shown too; usually in the middle of some other object):


![aaw_arb_20070104 0028_1_ldc0088](https://user-images.githubusercontent.com/15056653/41000182-69620bc2-6922-11e8-8bbd-26cd6c904737.png)
![arb-ng-2-76513-5614660_2_ldc0009](https://user-images.githubusercontent.com/15056653/41000183-6993b690-6922-11e8-8840-5d00077d53cb.png)
![arb-ng-2-76513-5614660_7_ldc0051](https://user-images.githubusercontent.com/15056653/41000184-69c0b622-6922-11e8-9d8b-80d3a9ac6d61.png)
![hyt_arb_20070103 0066_4_ldc0061](https://user-images.githubusercontent.com/15056653/41000185-69eff284-6922-11e8-886b-3c4beda099d7.png)
