### PR TITLE
not output background object

### DIFF
--- a/egs/dsb2018/v1/local/segment.py
+++ b/egs/dsb2018/v1/local/segment.py
@@ -37,6 +37,12 @@ parser.add_argument('--object-merge-factor', type=float, default=None,
 parser.add_argument('--same-different-bias', type=float, default=0.0,
                     help='Bias for same/different probs in the segmentation '
                     'algorithm.')
+parser.add_argument('--merge-logprob-bias', type=float, default=0.0,
+                    help='A bias that is added to merge logprobs in the '
+                    'segmentation algorithm.')
+parser.add_argument('--prune-threshold', type=float, default=0.0,
+                    help='Threshold used in the pruning step of the '
+                    'segmentation algorithm. Higher values --> more pruning.')
 parser.add_argument('--csv', type=str, default='sub-dsbowl2018.csv',
                     help='Csv filename as the final submission file')
 parser.add_argument('--job', type=int, default=0, help='job id')
@@ -135,7 +141,8 @@ def segment(dataloader, segment_dir, model, core_config):
         if args.object_merge_factor is None:
             args.object_merge_factor = 1.0 / len(offset_list)
             segmenter_opts = SegmenterOptions(same_different_bias=args.same_different_bias,
-                                              object_merge_factor=args.object_merge_factor)
+                                              object_merge_factor=args.object_merge_factor,
+                                              merge_logprob_bias=args.merge_logprob_bias)
         seg = ObjectSegmenter(class_pred[0].detach().numpy(),
                               adj_pred[0].detach().numpy(),
                               num_classes, offset_list,

--- a/scripts/waldo/data_visualization.py
+++ b/scripts/waldo/data_visualization.py
@@ -1,5 +1,6 @@
 # Copyright      2018  Johns Hopkins University (author: Daniel Povey, Desh Raj, Adel Rahimi)
 #                      Hossein Hadian
+#                      Yiwen Shao
 
 # Apache 2.0
 import matplotlib
@@ -10,7 +11,7 @@ import numpy as np
 from PIL import Image
 from io import BytesIO
 import operator
-
+from scipy import ndimage
 from waldo.data_types import *
 
 
@@ -22,51 +23,32 @@ def visualize_mask(x, c, transparency=0.7, show_labels=True):
     described by the parameter.
     x['img_with_mask'] = image with transparent mask overlay
     """
-
     validate_image_with_mask(x, c)
     im = x['img']
     mask = x['mask']
-
-    num_objects = np.unique(mask).shape[0]
-    colormap = plt.cm.get_cmap('hsv', num_objects)
-
-    shuffled_object_ids = np.random.permutation(np.array(list(range(num_objects))))
-    color_mask = np.array([colormap(shuffled_object_ids[i]) for i in mask])
-    obj2center = {}
-    obj2size = {}
-    for row in range(len(mask)):
-        for col in range(len(mask[row])):
-            objid = mask[row, col]
-            obj2center[objid] = (obj2center[objid] + (row, col) if objid in
-                                 obj2center else np.array((row, col)))
-            obj2size[objid] = (obj2size[objid] + 1 if objid in obj2size
-                               else 1)
-            objclass = x['object_class'][objid]
-            # set any background to white:
-            if objclass == 0: color_mask[row, col] = [1, 1, 1, 1]
-    for objid in obj2center:
-        obj2center[objid] = tuple(np.round(obj2center[objid] /
-                                           obj2size[objid]).astype(int))
     plt.clf()
     plt.imshow(im)
-    plt.imshow(color_mask, alpha=transparency)
-    if show_labels:
-        for objid in obj2center:
-            center = obj2center[objid]
-            color = colormap(shuffled_object_ids[objid])
-            plt.text(center[1] - 2, center[0] + 2, '{}'.format(objid), fontsize=7,
+    for i in range(1, mask.max() + 1):
+        b_mask = (mask == i)
+        base_img = np.ones((b_mask.shape[0], b_mask.shape[1], 3))
+        color = np.random.random((1, 3)).tolist()[0]
+        for k in range(3):
+            base_img[:, :, k] = color[k]
+        plt.imshow(np.dstack((base_img, b_mask * transparency)))
+        if show_labels:
+            center = np.round(ndimage.measurements.center_of_mass(b_mask))
+            plt.text(center[1] - 2, center[0] + 2, '{}'.format(i), fontsize=7,
                      color=color, bbox=dict(facecolor='white',
                                             edgecolor='none', pad=0))
 
-    plt.subplots_adjust(0,0,1,1)
+    plt.subplots_adjust(0, 0, 1, 1)
     buffer_ = BytesIO()
-    plt.savefig(buffer_, format = "png")
+    plt.savefig(buffer_, format="png")
     buffer_.seek(0)
     image = Image.open(buffer_)
     x['img_with_mask'] = np.array(image)
     buffer_.close()
     return x
-
 
 
 def visualize_polygons(x):

--- a/scripts/waldo/segmenter.py
+++ b/scripts/waldo/segmenter.py
@@ -260,7 +260,6 @@ class ObjectSegmenter:
         self.queue = []   # Python's heapq
         self.init_objects_and_adjacency_records()
 
-
     def default_options(self):
         return SegmenterOptions(same_different_bias=0.0,
                                 object_merge_factor=1.0,
@@ -324,7 +323,8 @@ class ObjectSegmenter:
         for obj in self.objects.values():
             for p in obj.pixels:
                 self.pixel2obj[p] = obj
-                tot_class_logprob += self.get_class_logprob(p, obj.object_class)
+                tot_class_logprob += self.get_class_logprob(
+                    p, obj.object_class)
         for row in range(self.img_height):
             for col in range(self.img_width):
                 p1 = (row, col)
@@ -334,12 +334,13 @@ class ObjectSegmenter:
                             0 <= col + o[1] < self.img_width):
                         obj2 = self.pixel2obj[(row + o[0], col + o[1])]
                         if obj1 is obj2 or obj1 == obj2:
-                            tot_sameness_logprob += np.log(self.get_sameness_prob(p1, i))
+                            tot_sameness_logprob += np.log(
+                                self.get_sameness_prob(p1, i))
                         else:
-                            tot_differentness_logprob += np.log(1.0 - self.get_sameness_prob(p1, i))
+                            tot_differentness_logprob += np.log(
+                                1.0 - self.get_sameness_prob(p1, i))
         return tot_class_logprob + (tot_differentness_logprob +
                                     tot_sameness_logprob) * self.opts.object_merge_factor
-
 
     def compute_total_logprob(self):
         tot_class_logprob = 0
@@ -391,13 +392,15 @@ class ObjectSegmenter:
         print("Pruned {} objects (merged into background). Final objects:"
               " {}".format(len(objects_to_be_merged), len(self.objects)))
 
-
     def output_mask(self):
         mask = np.zeros((self.img_height, self.img_width), dtype=int)
-        k = 0
-        object_class = [0] * len(self.objects)
+        k = 1
+        object_class = []
         for obj in self.objects.values():
-            object_class[k] = obj.object_class
+            # skip background object
+            if obj.object_class == 0:
+                continue
+            object_class.append(obj.object_class)
             for p in obj.pixels:
                 mask[p] = k
             k += 1
@@ -484,7 +487,8 @@ class ObjectSegmenter:
                     n, resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024 / 1024))
                 self.show_stats()
                 if self.do_debugging:
-                    print("Logprob from scratch: {}".format(self.compute_total_logprob_from_scratch()))
+                    print("Logprob from scratch: {}".format(
+                        self.compute_total_logprob_from_scratch()))
                 print("")
             if n > N:
                 print("Breaking after {} iters.".format(N))
@@ -523,7 +527,8 @@ class ObjectSegmenter:
         self.show_stats()
         self.visualize('final')
         if self.verbose >= 1:
-            print("Final logprob from scratch: {}".format(self.compute_total_logprob_from_scratch()))
+            print("Final logprob from scratch: {}".format(
+                self.compute_total_logprob_from_scratch()))
         return self.output_mask()
 
     def merge(self, arec):


### PR DESCRIPTION
Now only object class > 0 (not background) will be output. It solves problems that not all background pixels are merged into one object. This gives me a improvement from 0.37 to 0.40.

Also rewrite the visualization code so that only objects (not background) will have a mask and be totally transparent on other places.