### PR TITLE
add quotes to package names

### DIFF
--- a/scripts/dependencies/check_packages.py
+++ b/scripts/dependencies/check_packages.py
@@ -38,7 +38,10 @@ def gen_suggestion_str(dependencies_list):
         elif pkg == "torchvision" or "torchvision>" in pkg or "torchvision=" in pkg: 
             dependencies_list_special.append("torchvision")
         else:
-            dependencies_list_normal.append(pkg)
+            if ">" in pkg or "<" in pkg:
+                dependencies_list_normal.append("'" + pkg + "'")
+            else:
+                dependencies_list_normal.append(pkg)
 
     # generate package installation suggestions
     # [note] default packages installation location:


### PR DESCRIPTION
Thanks Jan Trmal for pointing this out.

> yes, it's there, but when the script suggests what packages are missing, it prints only something like
> 
> `pip3 install --user tensorboard_logger matplotlib>=2.2.2`
> 
> most people will only copy and paste the line, which will cause the > character to be interpreted by bash as redirection.
> That could cause even more problems if the ">" character wasn't part of the last package or if there were more package names including that character.
> 
> That's why I say those packages names should be quoted (as in they should have quotes around them), like this
> `pip3 install --user tensorboard_logger "matplotlib>=2.2.2"`
> (or just simply pip3 install --user "tensorboard_logger" "matplotlib>=2.2.2")